### PR TITLE
Remove Hackaburg, add next meeting

### DIFF
--- a/src/lib/termine.json
+++ b/src/lib/termine.json
@@ -1,13 +1,12 @@
 [
 	{
-		"title": "Hackaburg 2023",
+		"title": "Vereinssitzung",
 		"date": {
-			"day": "25",
-			"month": "Mai. 2023",
-			"time": "Do. 15.00"
+			"day": "27",
+			"month": "Jun. 2023",
+			"time": "Di. 18.00"
 		},
-		"description": "Hackaburg ist eine einzigartige Hackathon-Erfahrung, die mehr als 100 Entwickler*Innen, Designer*Innen und Unternehmer*Innen aus der ganzen Welt zusammenbringt.",
-		"link": "https://hackaburg.de/",
+		"description": "Du willst dem Hackaburg-Team beitreten und uns helfen, mehr coole Events auf die Beine zu stellen? Dann schau' bei unserer nächsten Sitzung in der Techbase vorbei!",
 		"image": "https://via.placeholder.com/700x250"
 	},
 	{
@@ -17,7 +16,7 @@
 			"month": "Jul. 2023",
 			"time": "Do. 18.30"
 		},
-		"description": "Lasst uns gemeinsam mit Comedyhacker Tobias Schrödel im Degginger in die spannende und spaßige Welt von Ransomwareangriffen und Cyberkriminellen abtauchen. Spaß garantiert! ",
+		"description": "Lasst uns gemeinsam mit Comedyhacker Tobias Schrödel im Degginger in die spannende und spaßige Welt von Ransomwareangriffen und Cyberkriminellen abtauchen. Spaß garantiert!",
 		"link": "https://eveeno.com/hackyhour",
 		"image": "https://via.placeholder.com/700x250"
 	}

--- a/src/routes/landing/Termine.svelte
+++ b/src/routes/landing/Termine.svelte
@@ -22,7 +22,9 @@
 						<p class="text-gray-700 text-base mb-8 md:mr-8">
 							{card.description}
 						</p>
-						<a class="text-lime-500 text-base mb-8 md:mr-8" href="{card.link}">Anmeldung & Details</a>
+						{#if card.link}
+							<a class="text-lime-500 text-base mb-8 md:mr-8" href="{card.link}">Anmeldung & Details</a>
+						{/if}
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
# Description

This PR updates the calendar, as Hackaburg 2023 is over now.
Furthermore, this PR adds the next club meeting at Techbase on June 27th.

To finish off this PR, I also made the link optional for events, as not every event we have (like club meetings) is going to have a dedicated website.

## Implementation details

Updates to termine.json

## What I have tested

I ran npm run dev.
